### PR TITLE
Convert float back to float

### DIFF
--- a/activerecord5-redshift-adapter.gemspec
+++ b/activerecord5-redshift-adapter.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.platform = Gem::Platform::RUBY
   s.name = 'activerecord5-redshift-adapter'
-  s.version = '2.0.3'
+  s.version = '2.0.4'
   s.summary = 'Amazon Redshift adapter for ActiveRecord '
   s.description = 'Amazon Redshift adapter for ActiveRecord 6.x.'
   s.license = 'MIT'

--- a/lib/active_record/connection_adapters/redshift_adapter.rb
+++ b/lib/active_record/connection_adapters/redshift_adapter.rb
@@ -82,7 +82,7 @@ module ActiveRecord
         string:      { name: "varchar" },
         text:        { name: "varchar" },
         integer:     { name: "integer" },
-        float:       { name: "decimal" },
+        float:       { name: "float" },
         decimal:     { name: "decimal" },
         datetime:    { name: "timestamp" },
         time:        { name: "timestamp" },


### PR DESCRIPTION
This change breaks our data migrations, so revert it back to the previous version.